### PR TITLE
Remove need for run script and add compatibility list

### DIFF
--- a/Compatibility.md
+++ b/Compatibility.md
@@ -1,0 +1,9 @@
+# Compatibility List
+
+## Known working games: 
+Here is a list of some games that have been tested and go in-game. It is not a complete list, there are probably more that work: 
+- Persona 5 Royal
+- Return of the Obra Dinn
+- Salt & Sanctuary
+- Final Fantasy Pixel Remasters
+- Hollow Knight

--- a/Compatibility.md
+++ b/Compatibility.md
@@ -7,3 +7,10 @@ Here is a list of some games that have been tested and go in-game. It is not a c
 - Salt & Sanctuary
 - Final Fantasy Pixel Remasters
 - Hollow Knight
+- The Legend of Zelda: Link's Awakening
+
+## Known non-working games:
+Here is a list of some games that have been tested and do not go in-game. It is not a complete list, there are probably more that don't work:
+- Super Mario Odyssey
+- The Legend of Zelda: Tears of The Kingdom
+- The Legend of Zelda: Breath of The Wild

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This script will build and compile Yuzu for macOS.
 
-Remember to not expect miracles, its not ready for end users yet, macOS build is still in development!
+Remember to not expect miracles, it's not ready for end users yet. The macOS build is still in development!
 
-This script is based of build instructions:
+This script is based off of these build instructions:
 https://yuzu-emu.org/wiki/building-for-macos/
 
 ## Original Yuzu's repository:
@@ -15,10 +15,10 @@ https://github.com/yuzu-emu/yuzu
 
 # Instructions:
 
-## 1. Clone the repository (or Code -> Download ZIP):
+## 1. Clone the repository (or Code -> Download ZIP). Examples here use the $HOME directory:
 
 ```
-$HOME && git clone https://github.com/mavethee/yuzu-macos-builds-script.git && cd yuzu-macos-builds-script
+$HOME && git clone https://github.com/mavethee/yuzu-macos-builds-script.git
 ```
 
 ## 2. Make sure cloned repo is up to date:
@@ -27,35 +27,39 @@ $HOME && git clone https://github.com/mavethee/yuzu-macos-builds-script.git && c
 cd $HOME/yuzu-macos-builds-script && git pull origin main
 ```
 
-## 3. Move both scripts preferably to $HOME directory:
+## 3. Move the script to a location on your drive:
 
 ```
-mv build_yuzu.sh $HOME && mv run_yuzu.sh $HOME
+mv build_yuzu.sh $HOME
 ```
 
-## 4. Make both scripts executable:
+## 4. Make the script executable:
 
 ```
-chmod +x $HOME/build_yuzu.sh && chmod +x $HOME/run_yuzu.sh
+chmod +x $HOME/build_yuzu.sh
 ```
 
-## 5. Run building script:
+## 5. Run the build script:
 
 ```
 $HOME/build_yuzu.sh
 ```
 
-## 6. Run executing script:
+## 6. Enjoy!
 
-```
-$HOME/run_yuzu.sh
-```
+Note: Remember to repeat STEP 2 for future script changes. </br>
+Yuzu currently does not support a lot of required features such as Geometry Shaders or Transform Feedback Buffers. </br>
+If a game you are trying to play uses these features, it will crash.
+If you want to know what missing feature is causing the crash, run yuzu through Terminal. </br>
+The situation will get better in the future as MoltenVK adds support for more features.
 
-## 7. Enjoy!
-
-Note: Remember to repeat STEP 2 for eventual script changes, most of Yuzu's GUI crashes for now, you can't switch to controller or change default settings being stuck to keyboard controls listed below:
-
-<img src="https://media.discordapp.net/attachments/724306793819275309/1111011104810877029/image.png"/> 
+## Known working games: 
+Here is a list of some games that have been tested and go in-game. It is not a complete list, there are probably more that work: 
+- Persona 5 Royal
+- Return of the Obra Dinn
+- Salt & Sanctuary
+- Final Fantasy Pixel Remasters
+- Hollow Knight
 
 # Credits:
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,6 @@ If a game you are trying to play uses these features, it will crash.
 If you want to know what missing feature is causing the crash, run yuzu through Terminal. </br>
 The situation will get better in the future as MoltenVK adds support for more features.
 
-## Known working games: 
-Here is a list of some games that have been tested and go in-game. It is not a complete list, there are probably more that work: 
-- Persona 5 Royal
-- Return of the Obra Dinn
-- Salt & Sanctuary
-- Final Fantasy Pixel Remasters
-- Hollow Knight
-
 # Credits:
 
 - Yuzu team:

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -79,6 +79,11 @@ if [ $? -eq 0 ]; then
         rm -rf "/Applications/yuzu.app"
     fi
 
+    echo -e "${PURPLE}Copying libraries to yuzu.app...${NC}"
+
+    mkdir ./bin/yuzu.app/Contents/Frameworks
+    cp /opt/homebrew/lib/libvulkan.dylib ./bin/yuzu.app/Contents/Frameworks/libvulkan.dylib
+    
     echo -e "${PURPLE}Moving yuzu.app to /Applications...${NC}"
 
     # Move yuzu.app to /Applications

--- a/run_yuzu.sh
+++ b/run_yuzu.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Export libVulkan path
-export LIBVULKAN_PATH=/opt/homebrew/lib/libvulkan.dylib
-
-# Run Yuzu
-/Applications/yuzu.app/Contents/MacOS/yuzu >> log.txt


### PR DESCRIPTION
Amend the build script so it copies over libvulkan.dylib into the app bundle. This allows the app to launch without a run script. 

Also add a compatibility list showing games that are known to at least go in-game. I've only added a few games that I have, so there are probably a lot more that work. 