### PR TITLE
Build using Qt6

### DIFF
--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -26,7 +26,7 @@ CORES=$(sysctl -n hw.ncpu)
 cd "$HOME"
 
 # Install needed dependencies
-brew install autoconf enet inih cubeb fmt automake boost ccache ffmpeg glslang hidapi libtool libusb lz4 ninja nlohmann-json openssl pkg-config qt@5 sdl2 speexdsp zlib zstd molten-vk vulkan-loader
+brew install autoconf enet inih cubeb fmt automake boost ccache ffmpeg glslang hidapi libtool libusb lz4 ninja nlohmann-json openssl pkg-config qt@6 sdl2 speexdsp zlib zstd molten-vk vulkan-loader
 
 echo -e "${PURPLE}Cloning or updating Yuzu repository...${NC}"
 
@@ -48,7 +48,6 @@ fi
 echo -e "${PURPLE}Exporting necessary environment variables...${NC}"
 
 # Export necessary environment variables
-export Qt5_DIR=$(brew --prefix)/opt/qt@5/lib/cmake
 export LLVM_DIR=$(brew --prefix)/opt/llvm@16
 export FFMPEG_DIR=$(brew --prefix)/opt/ffmpeg
 export cubeb_DIR=$(brew --prefix)/opt/cubeb
@@ -62,7 +61,7 @@ mkdir -p build && cd build
 echo -e "${PURPLE}Running CMake...${NC}"
 
 # Run CMake with specified options
-cmake .. -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DYUZU_USE_BUNDLED_VCPKG=OFF -DYUZU_TESTS=OFF -DENABLE_WEB_SERVICE=OFF -DENABLE_LIBUSB=OFF -DSDL_ARMNEON=ON
+cmake .. -GNinja -DCMAKE_BUILD_TYPE=RELEASE -DYUZU_USE_BUNDLED_VCPKG=OFF -DYUZU_TESTS=OFF -DENABLE_WEB_SERVICE=OFF -DENABLE_LIBUSB=OFF -DSDL_ARMNEON=ON -DENABLE_QT6=ON -DYUZU_USE_EXTERNAL_VULKAN_HEADERS=OFF
 
 echo -e "${PURPLE}Building Yuzu...${NC}"
 


### PR DESCRIPTION
Since homebrew versions of Qt5 and Qt6 don't co-exist happily, this commit updates to Qt6.

Works fine, but I've had to set `-DYUZU_USE_EXTERNAL_VULKAN_HEADERS=OFF` to avoid an error about an alias already existing. This is not ideal, because a user can update their local vulkan-headers independently and potentially break things. 

A fix for the alias issue would be preferred.

Also, I changed the build type to release, instead of release with debug info. This should in theory improve performance slightly. 