### PR TITLE
Add gettext to the dependencies

### DIFF
--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -26,7 +26,7 @@ CORES=$(sysctl -n hw.ncpu)
 cd "$HOME"
 
 # Install needed dependencies
-brew install autoconf automake boost ccache cubeb enet ffmpeg fmt glslang hidapi inih libtool libusb llvm@17 lz4 molten-vk ninja nlohmann-json openssl pkg-config qt@6 sdl2 speexdsp vulkan-loader zlib zstd
+brew install autoconf automake boost ccache cubeb enet ffmpeg fmt gettext glslang hidapi inih libtool libusb llvm@17 lz4 molten-vk ninja nlohmann-json openssl pkg-config qt@6 sdl2 speexdsp vulkan-loader zlib zstd
 
 echo -e "${PURPLE}Cloning or updating Yuzu repository...${NC}"
 


### PR DESCRIPTION
Required for the nx_tzdb fix on Sonoma and Apple Silicon.

nx_tzdb requires the `intl` library, but it seems to have been removed in newer versions of Sonoma. It is included in `gettext`  though, so we can add this to the dependencies list. 

Edit: Dependent on https://github.com/yuzu-emu/yuzu/pull/12634