### PR TITLE
Zsh + Remove core count + Brew install function 

### DIFF
--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -27,8 +27,9 @@ cd "$HOME"
 echo -e "${PURPLE}Checking for Homebrew dependencies...${NC}"
 brew_install() {
 	if [ -d "$(brew --prefix)/opt/$1" ]; then
-		echo "$1 found"
+		echo -e "${GREEN}found $1...${NC}"
 	else
+ 		echo -e "${RED}Did not find $1. Installing...${NC}"
 		brew install $1
 	fi
 }

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -26,7 +26,20 @@ CORES=$(sysctl -n hw.ncpu)
 cd "$HOME"
 
 # Install needed dependencies
-brew install autoconf automake boost ccache cubeb enet ffmpeg fmt glslang hidapi inih libtool libusb llvm@17 lz4 molten-vk ninja nlohmann-json openssl pkg-config qt@6 sdl2 speexdsp vulkan-loader zlib zstd
+brew_install() {
+	if brew list $1 &>/dev/null; then
+		echo "$1 found"
+	else
+		brew install $1
+	fi
+}
+
+deps=( autoconf automake boost ccache cubeb enet ffmpeg fmt glslang hidapi inih libtool libusb llvm@17 lz4 molten-vk ninja nlohmann-json openssl pkg-config qt@6 sdl2 speexdsp vulkan-loader zlib zstd )
+
+for dep in "${deps[@]}"
+do 
+	brew_install $dep
+done
 
 # Clone the Yuzu repository if not already cloned
 if [ ! -d "yuzu" ]; then

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -24,7 +24,7 @@ cd "$HOME"
 
 # Install needed dependencies
 brew_install() {
-	if brew list $1 &>/dev/null; then
+	if brew list --versions $1 &>/dev/null; then
 		echo "$1 found"
 	else
 		brew install $1

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -22,7 +22,9 @@ echo -e "${PURPLE}Heading to home directory...${NC}"
 # Change directory to $HOME
 cd "$HOME"
 
+
 # Install needed dependencies
+echo -e "${PURPLE}Checking for Homebrew dependencies...${NC}"
 brew_install() {
 	if [ -d "$(brew --prefix)/opt/$1" ]; then
 		echo "$1 found"

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -33,7 +33,7 @@ brew_install() {
 
 deps=( autoconf automake boost ccache cubeb enet ffmpeg fmt glslang hidapi inih libtool libusb llvm@17 lz4 molten-vk ninja nlohmann-json openssl pkg-config qt@6 sdl2 speexdsp vulkan-loader zlib zstd )
 
-for dep in "${deps[@]}"
+for dep in $deps[@]
 do 
 	brew_install $dep
 done

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -24,7 +24,7 @@ cd "$HOME"
 
 # Install needed dependencies
 brew_install() {
-	if brew list --versions $1 &>/dev/null; then
+	if [ -d "$(brew --prefix)/opt/$1" ]; then
 		echo "$1 found"
 	else
 		brew install $1

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -19,9 +19,6 @@ fi
 
 echo -e "${PURPLE}Heading to home directory...${NC}"
 
-# Amount of available cores:
-CORES=$(sysctl -n hw.ncpu)
-
 # Change directory to $HOME
 cd "$HOME"
 
@@ -80,8 +77,8 @@ cmake .. -GNinja -DCMAKE_BUILD_TYPE=RELEASE -DYUZU_USE_BUNDLED_VCPKG=OFF -DYUZU_
 
 echo -e "${PURPLE}Building Yuzu...${NC}"
 
-# Build Yuzu using Ninja with all available cores
-ninja -j${CORES}
+# Build Yuzu using Ninja
+ninja
 
 # Check if the build was successful
 if [ $? -eq 0 ]; then

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -29,7 +29,7 @@ brew_install() {
 	if [ -d "$(brew --prefix)/opt/$1" ]; then
 		echo -e "${GREEN}found $1...${NC}"
 	else
- 		echo -e "${RED}Did not find $1. Installing...${NC}"
+ 		echo -e "${PURPLE}Did not find $1. Installing...${NC}"
 		brew install $1
 	fi
 }

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env zsh
 
 # ANSI color codes
 PURPLE='\033[0;35m'


### PR DESCRIPTION
Made a few small changes: 

- Uses Zsh instead of Bash
- Removes core count and `-j${CORES}` arg from building
- Adds a function for installing brew dependencies [Needs Testing]

Reasons for the changes: 
1. Zsh is the default shell on macOS. It's not 100% compatible with Bash, but I tested the script and it works fine. 
2. According to [this article](https://spectra.mathpix.com/article/2024.01.00364/a-complete-guide-to-the-ninja-build-system) Ninja automatically uses the maximum number of cores available. There is no need to check. 
3. This will check for a brew installation before using the `brew install` command. Output is cleaner  ~~but it seems a bit slow to me. Maybe there is a better way to check, or maybe the existing command is faster.~~ Needs testing. Edit: Updated to check for presence in `$(brew --prefix)/opt/` , it is fast now. 