### PR TITLE
[Needs Testing] Only update necessary brew dependencies

### DIFF
--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -14,7 +14,7 @@ if ! command -v brew &> /dev/null; then
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 else
     echo -e "${PURPLE}Homebrew found. Updating Homebrew...${NC}"
-    brew update && brew upgrade
+    brew update
 fi
 
 echo -e "${PURPLE}Heading to home directory...${NC}"
@@ -22,12 +22,13 @@ echo -e "${PURPLE}Heading to home directory...${NC}"
 # Change directory to $HOME
 cd "$HOME"
 
-
 # Install needed dependencies
 echo -e "${PURPLE}Checking for Homebrew dependencies...${NC}"
 brew_install() {
 	if [ -d "$(brew --prefix)/opt/$1" ]; then
-		echo -e "${GREEN}found $1...${NC}"
+		echo -e "${GREEN}Found $1...${NC}"
+  		echo -e "${GREEN}Updating $1...${NC}"
+    		brew upgrade $1
 	else
  		echo -e "${PURPLE}Did not find $1. Installing...${NC}"
 		brew install $1

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -26,8 +26,7 @@ cd "$HOME"
 echo -e "${PURPLE}Checking for Homebrew dependencies...${NC}"
 brew_install() {
 	if [ -d "$(brew --prefix)/opt/$1" ]; then
-		echo -e "${GREEN}Found $1...${NC}"
-  		echo -e "${GREEN}Updating $1...${NC}"
+		echo -e "${GREEN}Found $1. Checking for updates...${NC}"
     		brew upgrade $1
 	else
  		echo -e "${PURPLE}Did not find $1. Installing...${NC}"

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -24,7 +24,7 @@ cd "$HOME"
 
 # Install needed dependencies
 echo -e "${PURPLE}Checking for Homebrew dependencies...${NC}"
-brew_install() {
+brew_dependency_check() {
 	if [ -d "$(brew --prefix)/opt/$1" ]; then
 		echo -e "${GREEN}Found $1. Checking for updates...${NC}"
     		brew upgrade $1
@@ -38,7 +38,7 @@ deps=( autoconf automake boost ccache cubeb enet ffmpeg fmt glslang hidapi inih 
 
 for dep in $deps[@]
 do 
-	brew_install $dep
+	brew_dependency_check $dep
 done
 
 # Clone the Yuzu repository if not already cloned

--- a/build_yuzu.sh
+++ b/build_yuzu.sh
@@ -29,7 +29,7 @@ brew_dependency_check() {
 		echo -e "${GREEN}Found $1. Checking for updates...${NC}"
     		brew upgrade $1
 	else
- 		echo -e "${PURPLE}Did not find $1. Installing...${NC}"
+ 		echo -e "${PURPLE}Could not find $1. Installing...${NC}"
 		brew install $1
 	fi
 }
@@ -47,13 +47,14 @@ if [ ! -d "yuzu" ]; then
     git clone --recursive https://github.com/yuzu-emu/yuzu
     cd yuzu
 else
-    echo -e "${PURPLE}Yuzu repository already exists. Updating...${NC}"
+    echo -e "${PURPLE}Yuzu repository already exists. Checking for updates...${NC}"
     cd yuzu
 
     echo -e "${PURPLE}Fetching latest changes...${NC}"
     
     git fetch origin master
 
+    # This only exist to avoid issues I had, but most of the time, just updating submodules work.
     echo -e "${PURPLE}Removing existing submodules...${NC}"
     git submodule deinit -f .
 
@@ -85,7 +86,7 @@ ninja
 
 # Check if the build was successful
 if [ $? -eq 0 ]; then
-    echo -e "Build ${GREEN}successful${NC}."
+    echo -e "${GREEN}Build successful${NC}."
 
     # Remove existing yuzu.app if it exists in /Applications
     if [ -d "/Applications/yuzu.app" ]; then
@@ -98,11 +99,11 @@ if [ $? -eq 0 ]; then
     # Move yuzu.app to /Applications
     mv bin/yuzu.app /Applications/
 
-    echo -e "${PURPLE}Installation completed.${NC}"
+    echo -e "${GREEN}Installation completed.${NC}"
 
     # Remove build folder
     cd "$HOME/yuzu"
     rm -rf build
 else
-    echo -e "Build ${RED}failed${NC}. Please check the build output for errors."
+    echo -e "${RED}Build failed. Please check the build output for errors.${NC}"
 fi


### PR DESCRIPTION
Moves the `brew upgrade` command to the dependency check.  

This should only upgrade the required dependencies rather than all installed brew packages, so the script should be faster if the user has lots of packages that they haven't updated in a while. 

Needs testing because I've kept my packages up to date... 🤦🏻‍♂️