### PR TITLE
[Needs Testing] Bundle Qt Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 <img src="./assets/icons/suyu.png" width="20%" height="20%" align="right"/> 
 
-🇵🇱 Szukasz Polskiego? [Kliknij tutaj](README_pl_PL.md)! You are reading English version! 🇺🇸
+#### 🇵🇱 Szukasz Polskiego? [Kliknij tutaj](README_pl_PL.md)! You are reading English version! 🇺🇸
 
 This script will build and compile Suyu for macOS on Apple Silicon.
 
 > [!WARNING]
 > This script is provided for experimentation purposes.<br> 
-> Don't expect high compatibility, there are reasons why an official Mac build hasn't been released yet.<br>
-> The macOS build is still in development!
+> Don't expect high compatibility, there are reasons why parent project to Suyu didn't get official Mac build.<br>
 
-Get it from here!
+
+#### Get it by pressing the button below or via [Releases](https://github.com/mavethee/suyu-macos-builds-script/releases) page :)
 
 [![Download](https://img.shields.io/badge/Download-v0.0.9-brightgreen)](https://github.com/mavethee/suyu-macos-builds-script/releases/download/0.0.9/build_suyu.sh)
 
@@ -21,8 +21,10 @@ After downloading, double click the script and follow the prompts.
 
 It is advised to run it from your home directory.
 
+#### You can check current macOS compatibility with apps and homebrews [here](./assets/compatibility/compatibility_pl_PL.md).
+
 > [!NOTE]
-> On a base M1, building takes ~4mins (measured including gathering needed dependencies which differs depending on your internet speed)
+> On a base M1, building takes ~6mins (measured including gathering needed dependencies which differs depending on your internet speed)
 > In case of any permission issues, run:
 > ```
 > chmod +x ./build_suyu.sh
@@ -36,16 +38,9 @@ It is advised to run it from your home directory.
 > /Applications/suyu.app/Contents/MacOS/suyu
 > ```
 >
-> If you want track everything to log file:
-> ```
-> /Applications/suyu.app/Contents/MacOS/suyu >> suyu.log
-> ```
+> You can also find a generated log file in `~/.local/share/suyu/log/suyu_log.txt`!
 >
 > The situation will get better in the future as MoltenVK adds support for more features.
-
-## Check current compatibility:
-
-[Compatiblity List](./assets/compatibility/compatibility.md)
 
 ## Contribution:
 
@@ -85,11 +80,12 @@ $HOME/build_suyu.sh
 ```sh
 Note: Remember to repeat STEP 2 for future script changes.
 ```
+
 ## Special thanks to:
 
-- Suyu's macOS build instructions archived [here](https://web.archive.org/web/20240113191459/https://yuzu-emu.org/wiki/building-for-macos/)
+- Suyu's macOS build instructions available [here](https://git.suyu.dev/suyu/suyu/wiki/Building-for-macOS)
 
-    ...and ChatGPT with GitHub Copilot for making my drunkass shell coding public.
+    ...and ChatGPT with GitHub Copilot for making my drunkass zsh scripting public.
 
 - [@shinra-electric](https://github.com/shinra-electric) for helping me maintain it and bringing some code quality 🍺
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 <img src="./assets/icons/suyu.png" width="20%" height="20%" align="right"/> 
 
-🇵🇱 Szukasz Polskiego? [Kliknij tutaj](README_pl_PL.md)! You are reading English version! 🇺🇸
+#### 🇵🇱 Szukasz Polskiego? [Kliknij tutaj](README_pl_PL.md)! You are reading English version! 🇺🇸
 
 This script will build and compile Suyu for macOS on Apple Silicon.
 
 > [!WARNING]
 > This script is provided for experimentation purposes.<br> 
-> Don't expect high compatibility, there are reasons why an official Mac build hasn't been released yet.<br>
-> The macOS build is still in development!
+> Don't expect high compatibility, there are reasons why parent project to Suyu didn't get official Mac build.<br>
 
-Get it from here!
+
+#### Get it by pressing the button below or via [Releases](https://github.com/mavethee/suyu-macos-builds-script/releases) page :)
 
 [![Download](https://img.shields.io/badge/Download-v0.0.9-brightgreen)](https://github.com/mavethee/suyu-macos-builds-script/releases/download/0.0.9/build_suyu.sh)
 
@@ -21,8 +21,10 @@ After downloading, double click the script and follow the prompts.
 
 It is advised to run it from your home directory.
 
+#### You can check current macOS compatibility with apps and homebrews [here](./assets/compatibility/compatibility.md).
+
 > [!NOTE]
-> On a base M1, building takes ~4mins (measured including gathering needed dependencies which differs depending on your internet speed)
+> On a base M1, building takes ~6mins (measured including gathering needed dependencies which differs depending on your internet speed)
 > In case of any permission issues, run:
 > ```
 > chmod +x ./build_suyu.sh
@@ -36,16 +38,9 @@ It is advised to run it from your home directory.
 > /Applications/suyu.app/Contents/MacOS/suyu
 > ```
 >
-> If you want track everything to log file:
-> ```
-> /Applications/suyu.app/Contents/MacOS/suyu >> suyu.log
-> ```
+> You can also find a generated log file in `~/.local/share/suyu/log/suyu_log.txt`!
 >
 > The situation will get better in the future as MoltenVK adds support for more features.
-
-## Check current compatibility:
-
-[Compatiblity List](./assets/compatibility/compatibility.md)
 
 ## Contribution:
 
@@ -85,11 +80,12 @@ $HOME/build_suyu.sh
 ```sh
 Note: Remember to repeat STEP 2 for future script changes.
 ```
+
 ## Special thanks to:
 
-- Suyu's macOS build instructions archived [here](https://web.archive.org/web/20240113191459/https://yuzu-emu.org/wiki/building-for-macos/)
+- Suyu's macOS build instructions available [here](https://git.suyu.dev/suyu/suyu/wiki/Building-for-macOS)
 
-    ...and ChatGPT with GitHub Copilot for making my drunkass shell coding public.
+    ...and ChatGPT with GitHub Copilot for making my drunkass zsh scripting public.
 
 - [@shinra-electric](https://github.com/shinra-electric) for helping me maintain it and bringing some code quality 🍺
 

--- a/README_pl_PL.md
+++ b/README_pl_PL.md
@@ -2,11 +2,13 @@
 
 <img src="./assets/icons/suyu.png" width="20%" height="20%" align="right"/> 
 
-🇵🇱 Czytasz polską wersje! Go to the 🇺🇸 English version [here](README.md).
+#### 🇵🇱 Czytasz polską wersje! Go to the 🇺🇸 English version [here](README.md).
 
 Ten skrypt pobierze wszystkie potrzebne rzeczy dla portu Suyu na macOS.
 
-Weź pod uwagę, żeby nie nastawiać się na wiele, w obecnym stanie nie jest to w pełni funkcjonalny port. 
+Weź pod uwagę, żeby nie nastawiać się na wiele, w obecnym stanie nie jest to w pełni funkcjonalny port.
+
+#### Pobierz klikając w przycisk poniżej lub [na stronie z poszczególnymi wersjami skryptu](https://github.com/mavethee/suyu-macos-builds-script/releases) :)
 
 [![Pobierz](https://img.shields.io/badge/Download-v0.0.9-brightgreen)](https://github.com/mavethee/suyu-macos-builds-script/releases/download/0.0.9/build_suyu.sh)
 
@@ -16,8 +18,10 @@ Po pobraniu, otwórz podwójnym klinięciem i postępuj zgodnie z poleceniami.
 
 Preferowane odpalenie skryptu w katalogu domowym.
 
+#### Sprawdź obecną kompatybilność dla portu na systemy macOS z poszczególnymi aplikacjami [tutaj](./assets/compatibility/compatibility_pl_PL.md).
+
 > [!NOTE]
-> W przypadku podstawowej konfiguracji na M1, kompilacja trwa ~4mins (pomiar zawiera również pobieranie potrzebnych plików do kompilacji, zależne od szybkości połączenia)
+> W przypadku podstawowej konfiguracji na M1, kompilacja trwa ~6mins (pomiar zawiera również pobieranie potrzebnych plików do kompilacji, zależne od szybkości połączenia)
 > W razie problemów z uprawnieniami:
 > ```
 > chmod +x ./build_suyu.sh
@@ -32,16 +36,9 @@ Preferowane odpalenie skryptu w katalogu domowym.
 > /Applications/suyu.app/Contents/MacOS/suyu >> suyu.log
 > ```
 >
-> Jeśli chcesz utworzyć plik dziennika zdarzeń:
-> ```
-> /Applications/suyu.app/Contents/MacOS/suyu >> suyu.log
-> ```
+> Plik dziennika znajdziesz w `~/.local/share/suyu/log/suyu_log.txt`!
 >
 > Sytuacja może ulec zmianie w przyszłości, gdy tylko MoltenVK doda wspracie dla większej ilości funkcji.
-
-## Sprawdź obecną kompatybilność:
-
-[Kompatybiliność](./assets/compatibility/compatibility_pl_PL.md)
 
 ## Contribution:
 
@@ -84,11 +81,11 @@ Notka: Pamiętaj o powtórzeniu kroku drugiego co jakiś czas, aby mieć najaktu
 
 ## Podziękowania:
 
--   Suyu's macOS build instructions archived [here](https://web.archive.org/web/20240113191459/https://yuzu-emu.org/wiki/building-for-macos/)
+-   Instrukcje kompilacji Suyu dla systemu macOS dostępnym [tutaj](https://git.suyu.dev/suyu/suyu/wiki/Building-for-macOS)
 
     ...oraz ChatGPT wraz GitHub Copilot za pomoc w upublicznieniu tego syfu.
 
--   [@shinra-electric](https://github.com/shinra-electric) za wszelkie poprawki do mojego pijackiego kodu! 🍻
+-   [@shinra-electric](https://github.com/shinra-electric) za wszelkie poprawki! 🍻
 
     Jeśli zostanę pozwany przez Big N, zapraszam na mój grób ^^
 

--- a/build_suyu.sh
+++ b/build_suyu.sh
@@ -107,7 +107,8 @@ cmake .. -GNinja \
     -DENABLE_QT6=ON \
     -DENABLE_QT_TRANSLATION=ON \
     -DSUYU_USE_EXTERNAL_VULKAN_HEADERS=OFF \
-    -DUSE_SYSTEM_MOLTENVK=OFF
+    -DUSE_SYSTEM_MOLTENVK=OFF \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 
 
 # Build Suyu using Ninja
 echo -e "${PURPLE}Building suyu using Ninja...${NC}"

--- a/build_suyu.sh
+++ b/build_suyu.sh
@@ -40,8 +40,7 @@ autoconf
 automake 
 boost 
 ccache 
-cmake 
-dylibbundler 
+cmake  
 ffmpeg 
 fmt 
 glslang 
@@ -90,6 +89,7 @@ fi
 echo -e "${PURPLE}Exporting necessary environment variables...${NC}"
 export LLVM_DIR=$(brew --prefix)/opt/llvm@17
 export FFMPEG_DIR=$(brew --prefix)/opt/ffmpeg
+export QT6_LOCATION=$(brew --prefix)/opt/qt
 
 # Create build folder
 echo -e "${PURPLE}Creating build folder...${NC}"
@@ -123,9 +123,15 @@ if [ $? -eq 0 ]; then
         rm -rf "/Applications/suyu.app"
     fi
 
-    # Bundle dependencies and codesign
-    echo -e "${PURPLE}Bundling and codesigning dependencies...${NC}"
-    dylibbundler -of -cd -b -x bin/suyu.app/Contents/MacOS/suyu -d bin/suyu.app/Contents/libs/
+    # Use macdeployq6 to copy Qt Frameworks. Also copies dylibs.
+    echo -e "${PURPLE}Bundling Qt6...${NC}"
+    # Bundle QtDBus.Framework manually because macdeployq6 won't do it
+    cp -R $QT6_LOCATION/lib/QtDBus.framework bin/suyu.app/Contents/Frameworks
+    macdeployqt6 bin/suyu.app
+    
+    # Codesign
+    echo -e "${PURPLE}Signing app bundle...${NC}"
+    codesign --force --deep --sign - bin/suyu.app
     
     # Move Suyu.app to /Applications
     echo -e "${PURPLE}Moving suyu.app to /Applications...${NC}"

--- a/build_suyu.sh
+++ b/build_suyu.sh
@@ -109,8 +109,6 @@ cmake .. -GNinja \
     -DSUYU_USE_EXTERNAL_VULKAN_HEADERS=OFF \
     -DUSE_SYSTEM_MOLTENVK=OFF
 
-echo -e "${PURPLE}Building suyu...${NC}"
-
 # Build Suyu using Ninja
 echo -e "${PURPLE}Building suyu using Ninja...${NC}"
 ninja


### PR DESCRIPTION
## Use Qt's `macdeployqt6` tool to bundle the Qt Frameworks:
- Need to manually add `QtDBus.Framework` because `macdeployqt6` doesn't,
- Remove `dylibbundler`, because `macdeployqt6` does its job,
- Codesign, because `dylibbundler` used to do that and `macdeployqt6` doesn't.

## Building:
- Added minimum target of macOS 11 Big Sur. This isn't needed for people running the app on the same Mac as building, but it is good for portability. Someone on Discord tested macOS 11 Big Sur and apparently that's ok. No point in going lower than 11.

## TODOs: 

- [ ] Check the app bundle to see that `QtCore`, `QtDBus`, `QtGui` and `QtWidgets` frameworks are there, as well as all the dylibs,
- [ ] Delete Qt from Homebrew,
- [ ] Check if the app can launch.